### PR TITLE
loosen magento version constrain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php" : "^7.0",
-        "magento/framework": "^100.1"
+        "magento/framework": "100.1 - 101.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",


### PR DESCRIPTION
The constrain 100.1 didn't cover newer versions of Magento. Specifically 2.2.x versions.