### PR TITLE
Plug into event manager instead of concrete implementation

### DIFF
--- a/Model/ManagerPlugin.php
+++ b/Model/ManagerPlugin.php
@@ -2,7 +2,7 @@
 
 namespace TrashPanda\CallableEventListeners\Model;
 
-use Magento\Framework\Event\Manager as MagentoEventManager;
+use Magento\Framework\Event\ManagerInterface as MagentoEventManager;
 
 /**
  * @author Aydin Hassan <aydin@wearejh.com>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,5 +1,5 @@
 <config>
-    <type name="\Magento\Framework\Event\Manager">
+    <type name="Magento\Framework\Event\ManagerInterface">
         <plugin name="callable_event_listeners" type="TrashPanda\CallableEventListeners\Model\ManagerPlugin"/>
     </type>
 </config>


### PR DESCRIPTION
Magento Commerce uses a different implementation of the `Magento\Framework\Event\ManagerInterface` interface, `Magento\Staging\Model\Event\Manager`, which the plugin wasn't triggering for. 

I have updated the code to reference the interface instead so that it triggers regardless of the concrete implementation used. 