### PR TITLE
Remove Magento dependency and widen php supported version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         }
     ],
     "require": {
-        "php" : "^7.0",
-        "magento/framework": "100.1 - 101.1"
+        "php" : ">=7.0 <7.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",


### PR DESCRIPTION
Hey dude

This module still works on PHP7.2 and newer versions of Magento, however the requirements in the composer.json file were too restrictive.

I have widen the range of PHP versions supported and removed the dependency on Magento framework altogether as this was trying to install multiple versions of Magento.